### PR TITLE
Add options to scanrips verb: bygroup, withgroups

### DIFF
--- a/DepotTests/CRUDTests/ScanRipsManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanRipsManagerTests.cs
@@ -448,13 +448,12 @@ namespace DepotTests.CRUDTests
 
             var visit = new MovieWarehouseVisit()
             {
-                MovieRips = new List<MovieRip>() { movieRip0, movieRip1, movieRip2, movieRip3, movieRip4 },
+                MovieRips = new List<MovieRip>() { movieRip0, movieRip1, movieRip2, movieRip3, movieRip4, movieRip5 },
                 VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null)
             };
             this._movieRipRepositoryMock
                 .Setup(m => m.GetAllRipsInVisit((It.Is<MovieWarehouseVisit>(v => v.VisitDateTime == visit.VisitDateTime))))
                 .Returns(visit.MovieRips);
-
 
             // act
             IEnumerable<KeyValuePair<string, int>> actual = this._scanRipsManager.GetRipCountByRipGroup(visit);

--- a/DepotTests/CRUDTests/ScanRipsManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanRipsManagerTests.cs
@@ -101,7 +101,7 @@ namespace DepotTests.CRUDTests
         }
 
         [Fact]
-        public void GetRipCountByVisit_ReturnsCorrectCount()
+        public void GetRipCountByVisit_ShouldReturnCorrectCount()
         {
             // arrange
             var visit_0 = new MovieWarehouseVisit() {
@@ -401,6 +401,72 @@ namespace DepotTests.CRUDTests
 
             // assert
             IEnumerable<MovieRip> expected = visit.MovieRips.Where(mr => expectedIds.Contains(mr.Id));
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+
+        [Fact]
+        public void GetRipCountByRipGroup_ShouldReturnCorrectCount()
+        {
+            // arrange
+            var movieRip0 = new MovieRip()
+            {
+                Id = 0,
+                FileName = "Terra.de.Abril.1977.DVDRip.x264-iSOMORFiSMO",
+                ParsedRipGroup = "iSOMORFiSMO"
+            };
+            var movieRip1 = new MovieRip()
+            {
+                Id = 1,
+                FileName = "Pedras.da.Saudade.1989.DVDRip.x264-iSOMORFiSMO",
+                ParsedRipGroup = "iSOMORFiSMO"
+            };
+            var movieRip2 = new MovieRip()
+            {
+                Id = 2,
+                FileName = "Possum.2018.1080p.WEB-DL.DD5.1.H264-FGT[EtHD]",
+                ParsedRipGroup = "FGT[EtHD]"
+            };
+            var movieRip3 = new MovieRip()
+            {
+                Id = 3,
+                FileName = "Stroszek.1977.GERMAN.1080p.BluRay.x264.DTS-FGT",
+                ParsedRipGroup = "FGT"
+            };
+            var movieRip4 = new MovieRip()
+            {
+                Id = 4,
+                FileName = "Cobra.Verde.1987.GERMAN.1080p.BluRay.x264.PSYCHD",
+                ParsedRipGroup = "PSYCHD"
+            };
+            var movieRip5 = new MovieRip()
+            {
+                Id = 5,
+                FileName = "Taxidermia.2006",
+                ParsedRipGroup = null
+            };
+
+            var visit = new MovieWarehouseVisit()
+            {
+                MovieRips = new List<MovieRip>() { movieRip0, movieRip1, movieRip2, movieRip3, movieRip4 },
+                VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null)
+            };
+            this._movieRipRepositoryMock
+                .Setup(m => m.GetAllRipsInVisit((It.Is<MovieWarehouseVisit>(v => v.VisitDateTime == visit.VisitDateTime))))
+                .Returns(visit.MovieRips);
+
+
+            // act
+            IEnumerable<KeyValuePair<string, int>> actual = this._scanRipsManager.GetRipCountByRipGroup(visit);
+
+            // assert
+            var expected = new KeyValuePair<string, int>[]
+            {
+                new KeyValuePair<string, int>("FGT", 2),
+                new KeyValuePair<string, int>("iSOMORFiSMO", 2),
+                new KeyValuePair<string, int>("PSYCHD", 1),
+                new KeyValuePair<string, int>("<empty>", 1)
+            };
             actual.Should().BeEquivalentTo(expected);
         }
 

--- a/FilmCRUD/Helpers/FileNameParser.cs
+++ b/FilmCRUD/Helpers/FileNameParser.cs
@@ -59,19 +59,23 @@ namespace FilmCRUD.Helpers
         {
             RipQualityRegex = new Regex(
                 $"(({_parenthesesOrBrackets_Left})*){_ripQualitySplitter}(({_parenthesesOrBrackets_Right})*)",
-                RegexOptions.IgnoreCase);
+                RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
             ReleaseTypeRegex = new Regex(
                 $"(({_parenthesesOrBrackets_Left})*){_ripReleaseTypeSplitter}(({_parenthesesOrBrackets_Right})*)",
-                RegexOptions.IgnoreCase);
+                RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            ParenthesesOrBrackets_LeftRegex = new Regex(_parenthesesOrBrackets_Left);
+            ParenthesesOrBrackets_LeftRegex = new Regex(_parenthesesOrBrackets_Left, RegexOptions.Compiled);
 
-            ParenthesesOrBrackets_RightRegex = new Regex(_parenthesesOrBrackets_Right);
+            ParenthesesOrBrackets_RightRegex = new Regex(_parenthesesOrBrackets_Right, RegexOptions.Compiled);
 
-            ReleaseDateSplitterRegex = new Regex($"(({_parenthesesOrBrackets_Left})*){_releaseDateSplitter}(({_parenthesesOrBrackets_Right})*)");
+            ReleaseDateSplitterRegex = new Regex(
+                $"(({_parenthesesOrBrackets_Left})*){_releaseDateSplitter}(({_parenthesesOrBrackets_Right})*)",
+                RegexOptions.Compiled);
 
-            AbsentReleaseDateRegex = new Regex($"^([a-z0-9]|{_tokenSplitter})*$", RegexOptions.IgnoreCase);
+            AbsentReleaseDateRegex = new Regex(
+                $"^([a-z0-9]|{_tokenSplitter})*$",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
             string _bracesLeft = @"\{";
             string _bracesRight = @"\}";

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -228,7 +228,7 @@ namespace FilmCRUD
                 Console.WriteLine($"ScanRips: rips with release group {opts.WithGroup}\n");
                 ripsWithGroup.OrderBy(mr => mr.FileName).ToList().ForEach(mr => Console.WriteLine(mr.FileName));
             }
-            else if (opts.CountByVisit)
+            else if (opts.ByVisit)
             {
                 Console.WriteLine("ScanRips: count by visit \n");
                 Dictionary<DateTime, int> countByVisit = scanRipsManager.GetRipCountByVisit();

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -219,6 +219,15 @@ namespace FilmCRUD
                     Console.WriteLine(fileName);
                 }
             }
+            else if (opts.WithGroup is not null)
+            {
+                Console.WriteLine($"Visit: {visit.VisitDateTime.ToString(printDateFormat)}");
+
+                IEnumerable<MovieRip> ripsWithGroup = scanRipsManager.GetRipsWithRipGroup(visit, opts.WithGroup);
+
+                Console.WriteLine($"ScanRips: rips with release group {opts.WithGroup}\n");
+                ripsWithGroup.OrderBy(mr => mr.FileName).ToList().ForEach(mr => Console.WriteLine(mr.FileName));
+            }
             else if (opts.CountByVisit)
             {
                 Console.WriteLine("ScanRips: count by visit \n");

--- a/FilmCRUD/Program.cs
+++ b/FilmCRUD/Program.cs
@@ -238,6 +238,17 @@ namespace FilmCRUD
                     Console.WriteLine($"{visitStr} : {item.Value}");
                 }
             }
+            else if (opts.ByGroup)
+            {
+                Console.WriteLine($"Visit: {visit.VisitDateTime.ToString(printDateFormat)}");
+
+                IEnumerable<KeyValuePair<string, int>> countByGroup = scanRipsManager.GetRipCountByRipGroup(visit);
+                Console.WriteLine("ScanRips: count by release group \n");
+                countByGroup
+                    .OrderByDescending(kvp => kvp.Value)
+                    .ToList()
+                    .ForEach(kvp => Console.WriteLine($"{kvp.Key}: {kvp.Value}"));
+            }
             else if (opts.VisitDiff.Any())
             {
                 GetVisitDiffAndPrint(

--- a/FilmCRUD/ScanRipsManager.cs
+++ b/FilmCRUD/ScanRipsManager.cs
@@ -98,5 +98,10 @@ namespace FilmCRUD
             return ripsInVisit.Where(mr => ripFileNameTokensIntersection[mr.Id].Any());
         }
 
+        public IEnumerable<MovieRip> GetRipsWithRipGroup(MovieWarehouseVisit visit, string ripGroup)
+        {
+            return new MovieRip[] { };
+        }
+
     }
 }

--- a/FilmCRUD/ScanRipsManager.cs
+++ b/FilmCRUD/ScanRipsManager.cs
@@ -117,5 +117,10 @@ namespace FilmCRUD
             return ripsInVisit.Where(mr => ripGroupRegex.IsMatch(mr.ParsedRipGroup));
         }
 
+        public IEnumerable<KeyValuePair<string, int>> GetRipCountByRipGroup(MovieWarehouseVisit visit)
+        {
+            return Array.Empty<KeyValuePair<string, int>>();
+        }
+
     }
 }

--- a/FilmCRUD/ScanRipsManager.cs
+++ b/FilmCRUD/ScanRipsManager.cs
@@ -104,10 +104,7 @@ namespace FilmCRUD
 
         public IEnumerable<MovieRip> GetRipsWithRipGroup(MovieWarehouseVisit visit, string ripGroup)
         {
-            string ripGroupWithoutSuffix = ripGroup.Trim();
-
-            if (Regex.IsMatch(ripGroup, $"{_squareBracketsSuffix}$", RegexOptions.IgnoreCase))
-                ripGroupWithoutSuffix = Regex.Replace(ripGroup, _squareBracketsSuffix, string.Empty, RegexOptions.IgnoreCase);
+            string ripGroupWithoutSuffix = RemoveSuffixFromRipGroup(ripGroup, toLower: true);
 
             var ripGroupRegex = new Regex($"{ripGroupWithoutSuffix}({_squareBracketsSuffix})*$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
@@ -120,6 +117,15 @@ namespace FilmCRUD
         public IEnumerable<KeyValuePair<string, int>> GetRipCountByRipGroup(MovieWarehouseVisit visit)
         {
             return Array.Empty<KeyValuePair<string, int>>();
+        }
+
+        private static string RemoveSuffixFromRipGroup(string ripGroup, bool toLower = true)
+        {
+            string ripGroupWithoutSuffix = toLower ? ripGroup.Trim() : ripGroup;
+
+            if (Regex.IsMatch(ripGroup, $"{_squareBracketsSuffix}$", RegexOptions.IgnoreCase))
+                ripGroupWithoutSuffix = Regex.Replace(ripGroup, _squareBracketsSuffix, string.Empty, RegexOptions.IgnoreCase);
+            return ripGroupWithoutSuffix;
         }
 
     }

--- a/FilmCRUD/ScanRipsManager.cs
+++ b/FilmCRUD/ScanRipsManager.cs
@@ -128,7 +128,7 @@ namespace FilmCRUD
 
         private static string RemoveSuffixFromRipGroup(string ripGroup, bool toLower = true)
         {
-            string ripGroupWithoutSuffix = toLower ? ripGroup.ToLower() : ripGroup;
+            string ripGroupWithoutSuffix = toLower ? ripGroup.Trim().ToLower() : ripGroup.Trim();
 
             if (Regex.IsMatch(ripGroup, $"{_squareBracketsSuffix}$", RegexOptions.IgnoreCase))
                 ripGroupWithoutSuffix = Regex.Replace(ripGroup, _squareBracketsSuffix, string.Empty, RegexOptions.IgnoreCase);

--- a/FilmCRUD/ScanRipsManager.cs
+++ b/FilmCRUD/ScanRipsManager.cs
@@ -116,12 +116,19 @@ namespace FilmCRUD
 
         public IEnumerable<KeyValuePair<string, int>> GetRipCountByRipGroup(MovieWarehouseVisit visit)
         {
-            return Array.Empty<KeyValuePair<string, int>>();
+            // ToList forces execution
+            IEnumerable<MovieRip> ripsInVisit = this.UnitOfWork.MovieRips.GetAllRipsInVisit(visit).ToList();
+
+            IEnumerable<IGrouping<string, MovieRip>> ripsByGroup = ripsInVisit.GroupBy(
+                mr => string.IsNullOrEmpty(mr.ParsedRipGroup) ?
+                    "<empty>"
+                    : RemoveSuffixFromRipGroup(mr.ParsedRipGroup, toLower: false));
+            return ripsByGroup.Select(group => new KeyValuePair<string, int>(group.Key, group.Count()));
         }
 
         private static string RemoveSuffixFromRipGroup(string ripGroup, bool toLower = true)
         {
-            string ripGroupWithoutSuffix = toLower ? ripGroup.Trim() : ripGroup;
+            string ripGroupWithoutSuffix = toLower ? ripGroup.ToLower() : ripGroup;
 
             if (Regex.IsMatch(ripGroup, $"{_squareBracketsSuffix}$", RegexOptions.IgnoreCase))
                 ripGroupWithoutSuffix = Regex.Replace(ripGroup, _squareBracketsSuffix, string.Empty, RegexOptions.IgnoreCase);

--- a/FilmCRUD/Verbs/ScanRipsOptions.cs
+++ b/FilmCRUD/Verbs/ScanRipsOptions.cs
@@ -35,6 +35,5 @@ namespace FilmCRUD.Verbs
         // can be used with any set; relevant for options WithDates and CountByReleaseDate
         [Option('v', "visit", HelpText = "warehouse visit date (YYYYMMDD) to use as the scan target; defaults to the most recent visit")]
         public string Visit { get; set; }
-
     }
 }

--- a/FilmCRUD/Verbs/ScanRipsOptions.cs
+++ b/FilmCRUD/Verbs/ScanRipsOptions.cs
@@ -22,6 +22,9 @@ namespace FilmCRUD.Verbs
         [Option(SetName = "CountRipsByVisit", HelpText = "rip count by visit")]
         public bool ByVisit { get; set; }
 
+        [Option(SetName = "CountRipsByRipGroup", HelpText = "rip count by release group")]
+        public bool ByGroup { get; set; }
+
         [Option(SetName = "LastVisitRipDifference", HelpText = "movie rip difference from last two visits: added and removed movie rips")]
         public bool LastVisitDiff { get; set; }
 

--- a/FilmCRUD/Verbs/ScanRipsOptions.cs
+++ b/FilmCRUD/Verbs/ScanRipsOptions.cs
@@ -16,11 +16,11 @@ namespace FilmCRUD.Verbs
         [Option(SetName = "GetRipsWithReleaseDates", HelpText = "list movies with parsed released dates YYYY")]
         public IEnumerable<int> WithDates { get; set; }
 
-        [Option(SetName = "GetRipsGroup", HelpText = "list movies with parsed parsed release group")]
+        [Option(SetName = "GetRipsWithGroup", HelpText = "list movies with parsed parsed release group")]
         public string WithGroup { get; set; }
 
         [Option(SetName = "CountRipsByVisit", HelpText = "rip count by visit")]
-        public bool CountByVisit { get; set; }
+        public bool ByVisit { get; set; }
 
         [Option(SetName = "LastVisitRipDifference", HelpText = "movie rip difference from last two visits: added and removed movie rips")]
         public bool LastVisitDiff { get; set; }

--- a/FilmCRUD/Verbs/ScanRipsOptions.cs
+++ b/FilmCRUD/Verbs/ScanRipsOptions.cs
@@ -16,6 +16,9 @@ namespace FilmCRUD.Verbs
         [Option(SetName = "GetRipsWithReleaseDates", HelpText = "list movies with parsed released dates YYYY")]
         public IEnumerable<int> WithDates { get; set; }
 
+        [Option(SetName = "GetRipsGroup", HelpText = "list movies with parsed parsed release group")]
+        public string WithGroup { get; set; }
+
         [Option(SetName = "CountRipsByVisit", HelpText = "rip count by visit")]
         public bool CountByVisit { get; set; }
 


### PR DESCRIPTION
- [x] bygroup: new `ScanRipsManager` method and tests
- [x] withgroup: new `ScanRipsManager` method and tests
- [x] new option in `ScanRipsOptions`: `withgroup`
- [x] amend `Program.HandleScanRipsOptions` to use new option `withgroup`
- [x] new option in `ScanRipsOptions`: `bygroup`
- [x] amend `Program.HandleScanRipsOptions` to use new option `bygroup`