### PR TITLE
ScanRipsManager: avoid passing nulls to regex match in GetRipsWithRipGroup method

### DIFF
--- a/DepotTests/CRUDTests/ScanRipsManagerTests.cs
+++ b/DepotTests/CRUDTests/ScanRipsManagerTests.cs
@@ -386,10 +386,16 @@ namespace DepotTests.CRUDTests
                 FileName = "Cobra.Verde.1987.GERMAN.1080p.BluRay.x264.PSYCHD",
                 ParsedRipGroup = "PSYCHD"
             };
+            var movieRip5 = new MovieRip()
+            {
+                Id = 5,
+                FileName = "Taxidermia.2006",
+                ParsedRipGroup = null
+            };
 
             var visit = new MovieWarehouseVisit()
             {
-                MovieRips = new List<MovieRip>() { movieRip0, movieRip1, movieRip2, movieRip3, movieRip4 },
+                MovieRips = new List<MovieRip>() { movieRip0, movieRip1, movieRip2, movieRip3, movieRip4, movieRip5 },
                 VisitDateTime = DateTime.ParseExact("20220101", "yyyyMMdd", null)
             };
             this._movieRipRepositoryMock

--- a/FilmCRUD/ScanRipsManager.cs
+++ b/FilmCRUD/ScanRipsManager.cs
@@ -110,10 +110,9 @@ namespace FilmCRUD
 
             // ToList forces execution
             IEnumerable<MovieRip> ripsInVisit = this.UnitOfWork.MovieRips.GetAllRipsInVisit(visit).ToList();
+             
 
-            return ripsInVisit.Where(mr => ripGroupRegex.IsMatch(mr.ParsedRipGroup));
-
-
+            return ripsInVisit.Where(mr => mr.ParsedRipGroup is not null && ripGroupRegex.IsMatch(mr.ParsedRipGroup));
         }
 
         public IEnumerable<KeyValuePair<string, int>> GetRipCountByRipGroup(MovieWarehouseVisit visit)

--- a/FilmCRUD/ScanRipsManager.cs
+++ b/FilmCRUD/ScanRipsManager.cs
@@ -112,6 +112,8 @@ namespace FilmCRUD
             IEnumerable<MovieRip> ripsInVisit = this.UnitOfWork.MovieRips.GetAllRipsInVisit(visit).ToList();
 
             return ripsInVisit.Where(mr => ripGroupRegex.IsMatch(mr.ParsedRipGroup));
+
+
         }
 
         public IEnumerable<KeyValuePair<string, int>> GetRipCountByRipGroup(MovieWarehouseVisit visit)


### PR DESCRIPTION
- [x] test with null case
- [x] amend method